### PR TITLE
Fix bugs in crawler

### DIFF
--- a/core/crawler.py
+++ b/core/crawler.py
@@ -259,24 +259,24 @@ class Crawler(object):
             forms = soup.findAll('form')
             for form in forms:
                 pars = {}
-                if "action" in form:
+                if "action" in form.attrs:
                     action_path = urllib.parse.urljoin(path, form["action"])
                 else:
                     action_path = path
                 for input_par in form.findAll('input'):
-                    if "name" not in input_par:
+                    if "name" not in input_par.attrs:
                         continue
                     value = "foo"
-                    if "value" in input_par and input_par["value"]:
+                    if "value" in input_par.attrs and input_par["value"]:
                         value = input_par["value"]
                     pars[input_par["name"]] = value
                 for input_par in form.findAll('select'):
                     pars[input_par["name"]] = "1"
                 if pars:
-                    links.append({"url":action_path + '?' + urllib.parse.urlencode(pars)})
+                    links.append({"href":action_path + '?' + urllib.parse.urlencode(pars)})
                 else:
                     self.report("form with no pars")
-                    links.append({"url":action_path})
+                    links.append({"href":action_path})
             links += self._emergency_parse(html_data, len(links))
         if self.verbose == 2:
             self.report(" "*(self._depth-depth) + path +" "+ str(len(links)))

--- a/core/curlcontrol.py
+++ b/core/curlcontrol.py
@@ -451,7 +451,10 @@ class Curl:
         m['request-size'] = str(self.handle.getinfo(pycurl.REQUEST_SIZE))
         m['response-code'] = str(self.handle.getinfo(pycurl.RESPONSE_CODE))
         m['ssl-verifyresult'] = str(self.handle.getinfo(pycurl.SSL_VERIFYRESULT))
-        m['content-type'] = (self.handle.getinfo(pycurl.CONTENT_TYPE) or '').strip(';')
+        try:
+            m['content-type'] = (self.handle.getinfo(pycurl.CONTENT_TYPE) or '').strip(';')
+        except Exception:
+            pass
         m['cookielist'] = str(self.handle.getinfo(pycurl.INFO_COOKIELIST))
         #m['content-length-download'] = str(self.handle.getinfo(pycurl.CONTENT_LENGTH_DOWNLOAD))
         #m['content-length-upload'] = str(self.handle.getinfo(pycurl.CONTENT_LENGTH_UPLOAD))

--- a/xsser
+++ b/xsser
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-"
 # vim: set expandtab tabstop=4 shiftwidth=4:
 """


### PR DESCRIPTION
Bugs fixed:
1. pycurl sometimes crashes when retrieving the content type, causing the crawler to crash.
2. tag attribute existence wasn't being checked properly
3. crawler form url processing was causing all form urls to be ignored
4. explicitly use python 3