### PR TITLE
Catch `OSError` from misidentified `socket` connection

### DIFF
--- a/core/tokenhub.py
+++ b/core/tokenhub.py
@@ -60,9 +60,12 @@ class HubThread(Thread):
     def client_finished(self, _thread):
         self._clients.remove(_thread)
     def shutdown(self):
-        if self.ready:
-            self.socket.shutdown(socket.SHUT_RDWR)
-            self.socket.close()
+        try:
+            if self.ready:
+                self.socket.shutdown(socket.SHUT_RDWR)
+                self.socket.close()
+        except OSError:
+            pass
         self.running = False
         self._armed = False
         self.ready = False


### PR DESCRIPTION
## Reproduce Error

Potential error found when attempting to run XSSer v1.8[2] on Google App-spot XSS playground. XSSer runs accordingly, but upon termination of payload injections, the command line tool quits with an `OSError`. 

#### Command used: 
```xsser -u 'https://xss-game.appspot.com/level1/frame' -g '?query=XSS' --auto --auto-set=2 --silent --save```

#### Result Error Log: 
```
Traceback (most recent call last):
  File "/usr/local/bin/xsser", line 36, in <module>
    app.land(True)
  File "/usr/local/lib/python3.7/site-packages/core/main.py", line 2779, in land
    self.hub.shutdown()
  File "/usr/local/lib/python3.7/site-packages/core/tokenhub.py", line 64, in shutdown
    self.socket.shutdown(socket.SHUT_RDWR)
OSError: [Errno 57] Socket is not connected
```
## Cause:

I believe this error is being thrown do to an incorrect state change causing `self.ready` in the `tokenhub.py` file to be set to `True` when in fact a socket is no longer active. Early termination by server or logic error in XSSer `shutdown` procedure may be the cause of this error being thrown.

## Solution:

Explicitly catch the `OSError` and allow for `self.ready` to be set to `False` in accordance with the rest of the code logic.

## Summary:

Socket is potentially incorrectly identified as being `connected`. Commit catches `OSError` thrown.